### PR TITLE
fix categories migration

### DIFF
--- a/db/migrate/20190123144139_remove_categories.rb
+++ b/db/migrate/20190123144139_remove_categories.rb
@@ -1,12 +1,12 @@
-class CreateCategories < ActiveRecord::Migration[5.2]
-  def self.up
+class RemoveCategories < ActiveRecord::Migration[5.2]
+  def self.down
     create_table :categories do |t|
       t.string :name
       t.timestamps
     end
   end
 
-  def self.down
+  def self.up
     drop_table :categories
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_23_124616) do
+ActiveRecord::Schema.define(version: 2019_01_23_144139) do
 
   create_table "articles", force: :cascade do |t|
     t.string "title"
@@ -18,12 +18,6 @@ ActiveRecord::Schema.define(version: 2019_01_23_124616) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "user_id"
-  end
-
-  create_table "categories", force: :cascade do |t|
-    t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
The CreateCategories migration was commented. I am assuming the intention was to undo this migration or to delete it.

In this PR the CreateCategories migration was edited and a new migration was added to remove the table.